### PR TITLE
Problem on Installing Streamdeckui on Linux Mint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ It is a work heavily in progress and we welcome any contributions.
 
 dbus & zenity
 
+Debian/Ubuntu and Linux Mint users need to install fallowing dependencies
+
+```
+udo apt install libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev
+```
+
 # Usage
 
 To use the streamdeck on unix you will need to have a daemon running.


### PR DESCRIPTION
Hi,

I got a problem while Installing streamdeckui on Linux Mint and after some research I found the solution, just install these packages

Because I received fallowing errors

```
# github.com/go-gl/glfw/v3.3/glfw
In file included from ./glfw/src/internal.h:188,
                 from ./glfw/src/context.c:30,
                 from go/pkg/mod/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20210410170116-ea3d685f79fb/c_glfw.go:4:
./glfw/src/x11_platform.h:36:10: fatal error: X11/Xcursor/Xcursor.h: No such file or directory
   36 | #include <X11/Xcursor/Xcursor.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~


# github.com/go-gl/glfw/v3.3/glfw
In file included from ./glfw/src/internal.h:188,
                 from ./glfw/src/context.c:30,
                 from go/pkg/mod/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20210410170116-ea3d685f79fb/c_glfw.go:4:
./glfw/src/x11_platform.h:39:10: fatal error: X11/extensions/Xrandr.h: No such file or directory
   39 | #include <X11/extensions/Xrandr.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~

```

Thank you
Mike