### PR TITLE
Fixed Installation procedure on Linux Mint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ It is a work heavily in progress and we welcome any contributions.
 
 dbus & zenity
 
+For Debian/Ubuntu and Linux Mint users fallowing depencencies are needed
+```
+sudo apt install libgl1-mesa-dev xorg-dev
+```
+
 # Usage
 
 To use the streamdeck on unix you will need to have a daemon running.


### PR DESCRIPTION
Hello,

I got a problem on Installing StreamdeckUI on Linux Mint, some depencencies were missing, so I did a bit of research and found out that the packages libgl1-mesa-dev xorg-dev were missing on my System, I guess it will not be installed by Default on Linux Mint, but I guess the same goes for Debian and Ubuntu but I didn't test it.

Thank you
Mike